### PR TITLE
Use go/scanner to extract import path

### DIFF
--- a/verifier.go
+++ b/verifier.go
@@ -251,7 +251,7 @@ func extractImportPath(line []byte) (string, error) {
 			return val, nil
 		case token.STRING:
 			if val != "" {
-				return "", fmt.Errorf("parsing failed, multiple strings on import line: %v", line)
+				return "", fmt.Errorf("parsing failed, multiple strings on import line: %v", string(line))
 			}
 			val = lit
 		}


### PR DESCRIPTION
This should be more reliable than stripping out unwanted parts of
the import line. Most notably it resolves #9

Note that I've not been able to verify this on an exhaustive set of
examples. Also note that there are still potential gotchas around
mutli line comments.. debatable whether or not those are worth
addressing (and definitely not wanting to cover in this PR, given
it has immediate benefits).

NB: this could potentially be expanded for parsing the entire import
section, rather than each line (I'm unsure how the lexer deals with
newlines)