### PR TITLE
Fix handling of comments in import groups

### DIFF
--- a/verifier_test.go
+++ b/verifier_test.go
@@ -125,3 +125,40 @@ import (
 func TestNotIgnoreGeneratedFileTestSuite(t *testing.T) {
 	suite.Run(t, new(NotIgnoreGeneratedFileTestSuite))
 }
+
+type ImportGroupWithCommentTestSuite struct {
+	VerifierTestSuite
+}
+
+func (s *ImportGroupWithCommentTestSuite) SetupSuite() {
+	s.options.Scheme = ImportGroupVerificationSchemeStdLocalThirdParty
+	s.options.LocalPrefix = "github.com/pavius/impi"
+}
+
+func (s *ImportGroupWithCommentTestSuite) TestValidAllGroups() {
+
+	verificationTestCases := []verificationTestCase{
+		{
+			name: "groups with comments",
+			contents: `
+package fixtures
+
+import (
+    "fmt"
+    // comment
+    "os" // comment
+    . "path" // comment
+
+    // comment
+    "github.com/pavius/impi/test"
+)
+`,
+			expectedErrorStrings: nil,
+		},
+	}
+	s.verifyTestCases(verificationTestCases)
+}
+
+func TestImportGroupWithCommentTestSuite(t *testing.T) {
+	suite.Run(t, new(ImportGroupWithCommentTestSuite))
+}


### PR DESCRIPTION
My apologies, I only noticed #10 introduced a slight regression after it was merged. Hopefully the commit message explains this well enough:

```
I noticed #10 introduced a regression in that a comments sitting on
a separate line are now ignored - leading to the `importInfo` "value"
being set to an empty string. This trips things up further along as
empty string implies a separate group. I've tried to address this
by retaining "value" as the raw value (renamed to `lineValue` for
clarity), and adding a new field to `importInfo` which contains the
import path, if valid for the given line.
```