### PR TITLE
Rework parsing of imports

### DIFF
--- a/stdlocalthirdpartyscheme_test.go
+++ b/stdlocalthirdpartyscheme_test.go
@@ -29,23 +29,41 @@ import (
 `,
 		},
 		{
+			name: "Std - single line (valid)",
+			contents: `package fixtures
+import . "fmt"
+`,
+		},
+		{
 			name: "Local (valid)",
 			contents: `package fixtures
 import (
     "github.com/pavius/impi/a"
     // some comment
-    "github.com/pavius/impi/b"
+    _ "github.com/pavius/impi/b" // comment
     "github.com/pavius/impi/c"
 )
+`,
+		},
+		{
+			name: "Local - single line (valid)",
+			contents: `package fixtures
+import "github.com/pavius/impi"
 `,
 		},
 		{
 			name: "Third party (valid)",
 			contents: `package fixtures
 import (
-    "github.com/another/3rdparty"
+    alias "github.com/another/3rdparty"
     "github.com/some/thirdparty"
 )
+`,
+		},
+		{
+			name: "Third party - single line (valid)",
+			contents: `package fixtures
+import alias "github.com/another/3rdparty" // comment
 `,
 		},
 		{
@@ -244,6 +262,25 @@ import (
 */
 import "C"
 `,
+		},
+		{
+			name: "3rd party group split into separate declaration",
+			contents: `package fixtures
+import (
+    "fmt"
+    "os"
+    "path"
+
+    "github.com/pavius/impi/a"
+    "github.com/pavius/impi/b"
+    "github.com/pavius/impi/c"
+)
+
+import "github.com/some/thirdparty"
+`,
+			expectedErrorStrings: []string{
+				"Multiple import declarations not permitted, 2 observed",
+			},
 		},
 	}
 

--- a/stdthirdpartylocalscheme_test.go
+++ b/stdthirdpartylocalscheme_test.go
@@ -29,6 +29,12 @@ import (
 `,
 		},
 		{
+			name: "Std - single line (valid)",
+			contents: `package fixtures
+import . "fmt"
+`,
+		},
+		{
 			name: "Local (valid)",
 			contents: `package fixtures
 import (
@@ -40,12 +46,24 @@ import (
 `,
 		},
 		{
+			name: "Local - single line (valid)",
+			contents: `package fixtures
+import "github.com/pavius/impi/a"
+`,
+		},
+		{
 			name: "Third party (valid)",
 			contents: `package fixtures
 import (
     "github.com/another/3rdparty"
     "github.com/some/thirdparty"
 )
+`,
+		},
+		{
+			name: "Third party - single line (valid)",
+			contents: `package fixtures
+import alias "github.com/another/3rdparty" // comment
 `,
 		},
 		{
@@ -224,6 +242,24 @@ import (
 `,
 			expectedErrorStrings: []string{
 				"Imports of different types are not allowed in the same group",
+			},
+		},
+		{
+			name: "Local group split into a separate declaration",
+			contents: `package fixtures
+import (
+    "fmt"
+    "os"
+    "path"
+
+    // another comment
+    "github.com/some/thirdparty"
+)
+
+import "github.com/pavius/impi"
+`,
+			expectedErrorStrings: []string{
+				"Multiple import declarations not permitted, 2 observed",
 			},
 		},
 	}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -148,12 +148,28 @@ import (
     // comment
     "os" // comment
     . "path" // comment
+    // comment
+
+    // standalone
+    // comment
+
+    /*
+     standalone
+     comment
+    */
 
     // comment
-    "github.com/pavius/impi/test"
+    "github.com/pavius/impi/a"
+    /*
+     comment line 1
+     comment line 2
+    */
+    _ "github.com/pavius/impi/b"
+    /*
+     comment
+    */
 )
 `,
-			expectedErrorStrings: nil,
 		},
 	}
 	s.verifyTestCases(verificationTestCases)


### PR DESCRIPTION
Hello, me again 👋 

#10 & #11 should have improved the handling of individual import lines to some extent, but I was conscious that it still wasn't going to be 100%. This is mainly because the line-by-line evaluation is imperfect by nature. Say for example we have some code that looks like:

```go
import (
	"fmt"
	/*
	"strings" "foo"
	*/
)
```

The line-by-line evaluation would incorrectly handle the lines inside of the comment. Before switching to `go/scanner` I believe this would have picked `"foo"` as an import, and later discarded it due the lack of line number obtained from the parser. After switching to `go/scanner` this now throws an error due to multiple possible import path strings on a single line. There is no easy fix with the current setup; we lack context to know what the line is (within a comment or an actual import).. it would be possible to supply line numbers to `getImportPos` but honestly it just feels a little neater to use the parser output entirely for this. The parser output can be used to obtain the import paths, and can make it easier to distinguish between different import declarations. With that in mind, I'll let the commit message explain the rest:

```
I mentioned in #10 that there are still potential gotchas by extracting
import info line-by-line. This attempts to address that along switching
to an even more reliable way of reading import information.

Given we're already parsing the the file for import line numbers, I
explored the idea of leaning on this information even more. As it turns
out this was viable - both comments and import path strings can be
obtained from the parsing output. This PR switches to using information
extracted solely via the parser, instead of the existing approach of
line-by-line evaluation with some information supplemented by the
parser.

Switching to the parser opened up some different possibilities. Most
notably it is now possible to deal with comments in a slightly better
way; instead of trying to pay attention but also ignore these at the
same time, the comment is handled in the same way the parser deals
with them; it is associated with the adjoining import line. This also
addresses one of the gotchas mentioned before: multi-line comments.
Assuming the multi-line comment is immediately adjoining, this is now
treated no different to single-line comments. Whilst visually these
comments may make the imports appear to be grouped separately,
semantically there is no difference. So IMO they should be treated the
same. In switching to this one other potential gotcha came to mind -
should comments be permitted that are standalone (i.e. unattached from
any import). Historically this tool has been sort of allowing for that
(certain bugs may have existed prior to switching to go/scanner). This
change allows for it, and I've covered that in the test case targeting
comment peculiarities.

Beyond that, I addressed one gotcha that wasn't discussed before: it is
entirely legal to have multiple import declarations. This is one point
where this tool likely has to become opinionated - should multiple be
permitted? Well, IMO, no (with the exception of the CGO `import "C"`
declaration). The existing implementation wouldn't take issue with this,
and when parsing line by line it would end up evaluating lines outside
of declarations (I think this is limited to comments, LPAREN and RPAREN
- which likely wouldn't trip things up after the switch to go/scanner).
The verifier now returns an error if there are multiple declarations
(`import "C"` excluded).

Finally, this addresses one final issue that #11 didn't cover - an
improperly formatted file could have unnecessary whitespace between
groups. Trimming the value of whitespace could have addressed this,
but we get a fix for free from this; the whitespace becomes irrelevant.
```

I hope these doesn't feel like too invasive a change. Having multiple import declarations result in an error is technically a breaking change, but hopefully workable (I don't believe this is common practise and wouldn't be surprised if some formatters/linters already take issue). As with before I haven't been able to test this exhaustively, though I have added to the tests to some degree :)