### PR TITLE
feat: allow multiple local packages

### DIFF
--- a/stdlocalthirdpartyscheme_test.go
+++ b/stdlocalthirdpartyscheme_test.go
@@ -12,7 +12,7 @@ type StdLocalAndThirdPartySchemeTestSuite struct {
 
 func (s *StdLocalAndThirdPartySchemeTestSuite) SetupSuite() {
 	s.options.Scheme = ImportGroupVerificationSchemeStdLocalThirdParty
-	s.options.LocalPrefix = "github.com/pavius/impi"
+	s.options.LocalPrefix = "github.com/pavius/impi,gitlab.com/pavius/impi"
 }
 
 func (s *StdLocalAndThirdPartySchemeTestSuite) TestValidAllGroups() {
@@ -36,6 +36,7 @@ import (
     // some comment
     "github.com/pavius/impi/b"
     "github.com/pavius/impi/c"
+    "gitlab.com/pavius/impi/d"
 )
 `,
 		},
@@ -86,6 +87,7 @@ import (
     // some comment
     "github.com/pavius/impi/b"
     "github.com/pavius/impi/c"
+    "gitlab.com/pavius/impi/d"
 
     // another comment
     "github.com/another/3rdparty"
@@ -105,6 +107,7 @@ import (
     // some comment
     "github.com/pavius/impi/b"
     "github.com/pavius/impi/c"
+    "gitlab.com/pavius/impi/d"
 
     // another comment
     "github.com/another/3rdparty"
@@ -128,6 +131,7 @@ import (
     "github.com/pavius/impi/b"
     // some comment
     "github.com/pavius/impi/c"
+    "gitlab.com/pavius/impi/d"
 )
 `,
 			expectedErrorStrings: []string{

--- a/stdthirdpartylocalscheme_test.go
+++ b/stdthirdpartylocalscheme_test.go
@@ -12,7 +12,7 @@ type StdThirdPartyLocalSchemeTestSuite struct {
 
 func (s *StdThirdPartyLocalSchemeTestSuite) SetupSuite() {
 	s.options.Scheme = ImportGroupVerificationSchemeStdThirdPartyLocal
-	s.options.LocalPrefix = "github.com/pavius/impi"
+	s.options.LocalPrefix = "github.com/pavius/impi,gitlab.com/pavius/impi"
 }
 
 func (s *StdThirdPartyLocalSchemeTestSuite) TestValidAllGroups() {
@@ -40,6 +40,18 @@ import (
 `,
 		},
 		{
+			name: "Multiple Local (valid)",
+			contents: `package fixtures
+import (
+    "github.com/pavius/impi/a"
+    // some comment
+    "github.com/pavius/impi/b"
+    "github.com/pavius/impi/c"
+    "gitlab.com/pavius/impi/d"
+)
+`,
+		},
+		{
 			name: "Third party (valid)",
 			contents: `package fixtures
 import (
@@ -47,6 +59,22 @@ import (
     "github.com/some/thirdparty"
 )
 `,
+		},
+		{
+			name: "Multiple Local (invalid)",
+			contents: `package fixtures
+import (
+    "gitlab.com/pavius/impi/d"
+    "github.com/pavius/impi/a"
+    // some comment
+    "github.com/pavius/impi/b"
+    "github.com/pavius/impi/c"
+    "gitlab.com/pavius/impi/d"
+)
+`,
+			expectedErrorStrings: []string{
+				`Import group 0 is not sorted`,
+			},
 		},
 		{
 			name: "Std -> Local (valid)",
@@ -108,6 +136,7 @@ import (
     // some comment
     "github.com/pavius/impi/b"
     "github.com/pavius/impi/c"
+    "gitlab.com/pavius/impi/d"
 )
 `,
 		},
@@ -123,6 +152,7 @@ import (
     "github.com/pavius/impi/b"
     // some comment
     "github.com/pavius/impi/c"
+    "gitlab.com/pavius/impi/d"
 
     // another comment
     "github.com/another/3rdparty"

--- a/verifier.go
+++ b/verifier.go
@@ -323,10 +323,14 @@ func (v *verifier) classifyImportTypes(importInfoGroups []importInfoGroup) {
 				continue
 			}
 
-			if strings.HasPrefix(importInfo.path, v.verifyOptions.LocalPrefix) {
-				importInfo.classifiedType = importTypeLocal
-			} else {
-				importInfo.classifiedType = importTypeThirdParty
+			for _, p := range strings.Split(v.verifyOptions.LocalPrefix, ",") {
+				p := strings.TrimSpace(p)
+				if strings.HasPrefix(importInfo.path, p) {
+					importInfo.classifiedType = importTypeLocal
+					break
+				} else {
+					importInfo.classifiedType = importTypeThirdParty
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We have more than one package that we consider local and when we run the validator it breaks. This change makes things equivalent to how `goimports` is handling things. See https://github.com/golang/go/issues/19188